### PR TITLE
Fixed non-matching parents with matching children being filtered out

### DIFF
--- a/gitlabber/gitlab_tree.py
+++ b/gitlabber/gitlab_tree.py
@@ -59,11 +59,18 @@ class GitlabTree:
 
     def filter_tree(self, parent):
         for child in parent.children:
-            if not self.is_included(child):
-                child.parent = None
-            if self.is_excluded(child):
-                child.parent = None
-            self.filter_tree(child)
+            if not child.is_leaf:
+                self.filter_tree(child)
+                if child.is_leaf:
+                    if not self.is_included(child):
+                        child.parent = None
+                    if self.is_excluded(child):
+                        child.parent = None
+            else:
+                if not self.is_included(child):
+                    child.parent = None
+                if self.is_excluded(child):
+                    child.parent = None
 
     def root_path(self, node):
         return "/".join([str(n.name) for n in node.path])

--- a/tests/test_gitlab_tree.py
+++ b/tests/test_gitlab_tree.py
@@ -23,6 +23,16 @@ def test_filter_tree_include_negative(monkeypatch):
     assert len(gl.root.children) == 0
 
 
+def test_filter_tree_include_deep_positive(monkeypatch):
+    gl = gitlab_util.create_test_gitlab(monkeypatch, includes=["/group/subgroup/project"])
+    gl.load_tree()
+    assert gl.root.is_leaf is False
+    assert len(gl.root.children) == 1
+    assert len(gl.root.children[0].children) == 1
+    assert len(gl.root.children[0].children[0].children) == 1
+    assert gl.root.children[0].children[0].children[0].is_leaf is True
+
+
 def test_filter_tree_exclude_positive(monkeypatch):
     gl = gitlab_util.create_test_gitlab(monkeypatch, excludes=["/group**"])
     gl.load_tree()


### PR DESCRIPTION
If for example a group hierarchy of /A/B/C exists, with repositories /A/B/C/D and /A/B/C/E below group C, and I attempt to use gitlabber to check out everything in group /A/B/C by including '/A/B/C**, gitlabber will not check out anything, but claim that the tree was empty.

The reason for this is that the recursive tree filtering algorithm appears to expect parent nodes in the group tree to match the include/exclude rules specified, which of course is not true for /A or /A/B in the example above. Neither does a user expect to have to specify include rules for each parent group up to the root - it is expected that the include match or no-match happens on repositories, not parent group nodes. Therefore, the matching logic must be applied to leaf nodes (repositories) only, and for all nodes in between (groups) the rule is that they must not be eliminated if they have any children that survived the filtering.