### PR TITLE
add parameter --path to use project path instead of project name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,32 +81,33 @@ Usage
 
 .. code-block:: bash
 
-    usage: gitlabber [-h] [-t token] [-u url] [--verbose] [-p]
-                    [--print-format {json,yaml,tree}] [-m {ssh,https}] [-i csv]
-                    [-x csv] [--version]
+    usage: gitlabber [-h] [--path] [-t token] [-u url] [--verbose] [-p]
+                    [--print-format {json,yaml,tree}] [-m {ssh,https}]
+                    [-i csv] [-x csv] [--version]
                     [dest]
 
     Gitlabber - clones or pulls entire groups/projects tree from gitlab
 
     positional arguments:
-    dest                  destination path for the cloned tree (created if doesn't exist)
+      dest                  destination path for the cloned tree (created if doesn't exist)
 
     optional arguments:
-    -h, --help            show this help message and exit
-    -t token, --token token
+      -h, --help            show this help message and exit
+      --path                use project path instead of project name
+      -t token, --token token
                             gitlab personal access token https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html
-    -u url, --url url     base gitlab url (e.g.: 'http://gitlab.mycompany.com')
-    --verbose             print more verbose output
-    -p, --print           print the tree without cloning
-    --print-format {json,yaml,tree}
+      -u url, --url url     base gitlab url (e.g.: 'http://gitlab.mycompany.com')
+      --verbose             print more verbose output
+      -p, --print           print the tree without cloning
+      --print-format {json,yaml,tree}
                             print format (default: 'tree')
-    -m {ssh,http}, --method {ssh,http}
+      -m {ssh,http}, --method {ssh,http}
                             the method to use for cloning (either "ssh" or "http")
-    -i csv, --include csv
+      -i csv, --include csv
                             comma delimited list of glob patterns of paths to projects or groups to clone/pull
-    -x csv, --exclude csv
+      -x csv, --exclude csv
                             comma delimited list of glob patterns of paths to projects or groups to exclude from clone/pull
-    --version             print the version
+      --version             print the version
 
     examples:
 
@@ -128,6 +129,9 @@ Usage
 
         clone projects that start with a case insensitive 'w' using a regular expression:
         gitlabber -i '/{[w].*}' .
+
+        clone an entire gitlab tree using the project path instead of project name:
+        gitlabber --path .
 
 Debugging 
 ---------

--- a/gitlabber/cli.py
+++ b/gitlabber/cli.py
@@ -31,7 +31,7 @@ def main():
     includes=split(args.include)
     excludes=split(args.exclude)
     tree = GitlabTree(args.url, args.token, args.method, includes,
-                      excludes, args.file, args.concurrency, args.verbose)
+                      excludes, args.file, args.concurrency, args.verbose, args.path)
     log.debug("Reading projects tree from gitlab at [%s]", args.url)
     tree.load_tree()
 
@@ -92,6 +92,11 @@ def parse_args(argv=None):
         nargs='?', 
         type=validate_path,
         help='destination path for the cloned tree (created if doesn\'t exist)')
+    parser.add_argument(
+        '--path',
+        action='store_true',
+        help='use project path instead of project name'
+    )
     parser.add_argument(
         '-t',
         '--token',
@@ -154,6 +159,7 @@ def parse_args(argv=None):
         '--version',
         action='store_true',
         help='print the version')
+
 
     args = parser.parse_args(argv)
     args_print = vars(args).copy()

--- a/tests/gitlab_test_utils.py
+++ b/tests/gitlab_test_utils.py
@@ -24,6 +24,7 @@ class MockNode:
     def __init__(self, id, name, url, subgroups=mock.MagicMock(), projects=mock.MagicMock(), parent_id=None):
         self.id = id
         self.name = name
+        self.path = name
         self.url = url
         self.web_url = url
         self.ssh_url_to_repo = url

--- a/tests/gitlab_test_utils.py
+++ b/tests/gitlab_test_utils.py
@@ -87,9 +87,9 @@ def validate_tree(root):
     validate_project(root.children[0].children[0].children[0])
 
 
-def create_test_gitlab(monkeypatch, includes=None, excludes=None, in_file=None):
+def create_test_gitlab(monkeypatch, includes=None, excludes=None, in_file=None, use_path=False):
     gl = gitlab_tree.GitlabTree(
-        URL, TOKEN, "ssh", includes=includes, excludes=excludes, in_file=in_file)
+        URL, TOKEN, "ssh", includes=includes, excludes=excludes, in_file=in_file, use_path=use_path)
     projects = Listable(MockNode(2, PROJECT_NAME, PROJECT_URL))
     subgroup_node = MockNode(2, SUBGROUP_NAME, SUBGROUP_URL, projects=projects)
     subgroups = Listable(subgroup_node)

--- a/tests/test-output.json
+++ b/tests/test-output.json
@@ -5,21 +5,25 @@
         {
           "children": [
             {
+              "dir_path": "project",
               "name": "project",
               "root_path": "/group/subgroup/project",
               "url": "http://gitlab.my.com/group/subgroup/project/project.git"
             }
           ],
+          "dir_path": "subgroup",
           "name": "subgroup",
           "root_path": "/group/subgroup",
           "url": "http://gitlab.my.com/group/subgroup"
         }
       ],
+      "dir_path": "group",
       "name": "group",
       "root_path": "/group",
       "url": "http://gitlab.my.com/group"
     }
   ],
+  "dir_path": "",
   "name": "",
   "root_path": "",
   "url": "http://gitlab.my.com/"

--- a/tests/test-output.yaml
+++ b/tests/test-output.yaml
@@ -1,15 +1,19 @@
 children:
 - children:
   - children:
-    - name: project
+    - dir_path: project
+      name: project
       root_path: /group/subgroup/project
       url: http://gitlab.my.com/group/subgroup/project/project.git
+    dir_path: subgroup
     name: subgroup
     root_path: /group/subgroup
     url: http://gitlab.my.com/group/subgroup
+  dir_path: group
   name: group
   root_path: /group
   url: http://gitlab.my.com/group
+dir_path: ''
 name: ''
 root_path: ''
 url: http://gitlab.my.com/

--- a/tests/test_gitlab_tree.py
+++ b/tests/test_gitlab_tree.py
@@ -79,6 +79,10 @@ def test_print_tree_yaml(monkeypatch):
             output_file = yaml.safe_load(yamlFile)
             assert yaml.dump(output_file) == yaml.dump(output)
 
+def test_tree_use_path(monkeypatch):
+    gl = gitlab_util.create_test_gitlab(monkeypatch, use_path=True)
+    gl.load_tree()
+    gitlab_util.validate_tree(gl.root)
 
 def test_load_tree_from_file(monkeypatch):
     gl = gitlab_util.create_test_gitlab(


### PR DESCRIPTION
Make it possible to generate folder names based on group and project path instead of group and project name.

Possible FIX #25 and FIX #38.