### PR TITLE
add support for folder naming strategy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,19 +47,21 @@ Usage
 -----
 
 * Arguments can be provided via the CLI arguments directly or via environment variables::
-    +---------------+---------------+--------------------------+
-    | Argument      | Flag          | Environment Variable     |
-    +===============+===============+==========================+
-    | token         | -t            | `GITLAB_TOKEN`           |
-    +---------------+---------------+--------------------------+
-    | url           | -u            | `GITLAB_URL`             |
-    +---------------+---------------+--------------------------+
-    | method        | -m            | `GITLABBER_CLONE_METHOD` |
-    +---------------+---------------+--------------------------+
-    | include       | -i            | `GITLABBER_INCLUDE`      |
-    +---------------+---------------+--------------------------+
-    | exclude       | -x            | `GITLABBER_EXCLUDE`      |
-    +---------------+---------------+--------------------------+
+    +---------------+---------------+---------------------------+
+    | Argument      | Flag          | Environment Variable      |
+    +===============+===============+===========================+
+    | token         | -t            | `GITLAB_TOKEN`            |
+    +---------------+---------------+---------------------------+
+    | url           | -u            | `GITLAB_URL`              |
+    +---------------+---------------+---------------------------+
+    | method        | -m            | `GITLABBER_CLONE_METHOD`  |
+    +---------------+---------------+---------------------------+
+    | naming        | -n            | `GITLABBER_FOLDER_NAMING` |
+    +---------------+---------------+---------------------------+
+    | include       | -i            | `GITLABBER_INCLUDE`       |
+    +---------------+---------------+---------------------------+
+    | exclude       | -x            | `GITLABBER_EXCLUDE`       |
+    +---------------+---------------+---------------------------+
 
 * To view the tree run the command with your includes/excludes and the `-p` flag it will print your tree like so
 
@@ -100,8 +102,10 @@ Usage
     -p, --print           print the tree without cloning
     --print-format {json,yaml,tree}
                             print format (default: 'tree')
+    -n {name,path}, --naming {name,path}
+                            the folder naming strategy for projects (default: "name")
     -m {ssh,http}, --method {ssh,http}
-                            the method to use for cloning (either "ssh" or "http")
+                            the method to use for cloning (default: "ssh")
     -i csv, --include csv
                             comma delimited list of glob patterns of paths to projects or groups to clone/pull
     -x csv, --exclude csv
@@ -145,5 +149,5 @@ Toubleshooting
 Known Limitations
 -----------------
 * Cloning vs Pulling: when running Gitlabber consecutively with same parameters it will scan the local tree structure, if the project directory exists and is a valid git repository (has .git folder in it) gitlabber will perform a git pull in the directory, otherwise the project directory will be created and the gitlab project will be cloned into it. 
-* Gitlabber doesn't maintain local state and will not rename local projects but rather clone them into new directories
-* Gitlabber uses project / group paths on the server and not their names, Gitlab doesn't impose the same restriction on name duplication of groups / projects as filesystems do with folders.
+* Project Renaming: Gitlabber doesn't maintain local state and will not rename local projects but rather clone them into new directories
+* Folder Naming Strategy: consecutively running gitlabber with different values for the `-n` parameter will produce undesirable results, keep the same value as previous runs or simply don't change it from the default (project name)

--- a/gitlabber/cli.py
+++ b/gitlabber/cli.py
@@ -8,6 +8,7 @@ from argparse import ArgumentParser, RawTextHelpFormatter, FileType, SUPPRESS
 from .gitlab_tree import GitlabTree
 from .format import PrintFormat
 from .method import CloneMethod
+from .naming import FolderNaming
 from . import __version__ as VERSION
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -30,7 +31,7 @@ def main():
     config_logging(args)
     includes=split(args.include)
     excludes=split(args.exclude)
-    tree = GitlabTree(args.url, args.token, args.method, includes,
+    tree = GitlabTree(args.url, args.token, args.method, args.naming, includes,
                       excludes, args.file, args.concurrency, args.verbose)
     log.debug("Reading projects tree from gitlab at [%s]", args.url)
     tree.load_tree()
@@ -132,12 +133,19 @@ def parse_args(argv=None):
         choices=list(PrintFormat),
         help='print format (default: \'tree\')')
     parser.add_argument(
+        '-n',
+        '--naming',
+        type=FolderNaming.argparse,
+        choices=list(FolderNaming),
+        default=os.environ.get('GITLABBER_FOLDER_NAMING', "name"),
+        help='the folder naming strategy for projects from the gitlab API attributes (default: "name")')
+    parser.add_argument(
         '-m',
         '--method',
         type=CloneMethod.argparse,
         choices=list(CloneMethod),
         default=os.environ.get('GITLABBER_CLONE_METHOD', "ssh"),
-        help='the method to use for cloning (either "ssh" or "http")')
+        help='the method to use for cloning (default: "ssh")')
     parser.add_argument(
         '-i',
         '--include',

--- a/gitlabber/gitlab_tree.py
+++ b/gitlabber/gitlab_tree.py
@@ -5,6 +5,7 @@ from anytree.importer import DictImporter
 from .git import sync_tree
 from .format import PrintFormat
 from .method import CloneMethod
+from .naming import FolderNaming
 from .progress import ProgressBar
 import yaml
 import io
@@ -16,13 +17,14 @@ log = logging.getLogger(__name__)
 
 class GitlabTree:
 
-    def __init__(self, url, token, method, includes=[], excludes=[], in_file=None, concurrency=1, disable_progress=False):
+    def __init__(self, url, token, method, naming, includes=[], excludes=[], in_file=None, concurrency=1, disable_progress=False):
         self.includes = includes
         self.excludes = excludes
         self.url = url
         self.root = Node("", root_path="", url=url)
         self.gitlab = Gitlab(url, private_token=token)
         self.method = method
+        self.naming = naming
         self.in_file = in_file
         self.concurrency = concurrency
         self.disable_progress = disable_progress
@@ -82,8 +84,9 @@ class GitlabTree:
 
     def add_projects(self, parent, projects):
         for project in projects:
+            project_id = project.name if self.method is FolderNaming.NAME else project.path
             project_url = project.ssh_url_to_repo if self.method is CloneMethod.SSH else project.http_url_to_repo
-            node = self.make_node(project.name, parent,
+            node = self.make_node(project_id, parent,
                                   url=project_url)
             self.progress.show_progress(node.name, 'project')
 

--- a/gitlabber/naming.py
+++ b/gitlabber/naming.py
@@ -1,0 +1,18 @@
+import enum 
+
+class FolderNaming(enum.IntEnum):
+    NAME = 1
+    PATH = 2
+
+    def __str__(self):
+        return self.name.lower()
+
+    def __repr__(self):
+        return str(self)
+
+    @staticmethod
+    def argparse(s):
+        try:
+            return FolderNaming[s.upper()]
+        except KeyError:
+            return s

--- a/tests/gitlab_test_utils.py
+++ b/tests/gitlab_test_utils.py
@@ -24,6 +24,7 @@ class MockNode:
     def __init__(self, id, name, url, subgroups=mock.MagicMock(), projects=mock.MagicMock(), parent_id=None):
         self.id = id
         self.name = name
+        self.path = name
         self.url = url
         self.web_url = url
         self.ssh_url_to_repo = url
@@ -88,7 +89,7 @@ def validate_tree(root):
 
 def create_test_gitlab(monkeypatch, includes=None, excludes=None, in_file=None):
     gl = gitlab_tree.GitlabTree(
-        URL, TOKEN, "ssh", includes=includes, excludes=excludes, in_file=in_file)
+        URL, TOKEN, "ssh", "name", includes=includes, excludes=excludes, in_file=in_file)
     projects = Listable(MockNode(2, PROJECT_NAME, PROJECT_URL))
     subgroup_node = MockNode(2, SUBGROUP_NAME, SUBGROUP_URL, projects=projects)
     subgroups = Listable(subgroup_node)
@@ -98,7 +99,7 @@ def create_test_gitlab(monkeypatch, includes=None, excludes=None, in_file=None):
     return gl
 
 def create_test_gitlab_with_toplevel_subgroups(monkeypatch):
-    gl = gitlab_tree.GitlabTree(URL, TOKEN, "ssh")
+    gl = gitlab_tree.GitlabTree(URL, TOKEN, "ssh", "path")
     groups = Listable([MockNode(2, GROUP_NAME, GROUP_URL),
                        MockNode(2, GROUP_NAME, GROUP_URL, parent_id=1)])
     monkeypatch.setattr(gl.gitlab, "groups", groups)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import tests.output_test_utils as output_util
 
 from gitlabber.format import PrintFormat
 from gitlabber.method import CloneMethod
+from gitlabber.naming import FolderNaming
 from unittest import mock
 from anytree import Node
 import pytest
@@ -32,7 +33,7 @@ def test_args_version():
 def test_args_logging(mock_tree, mock_log, mock_os, mock_sys, mock_logging):
     args_mock = mock.Mock()
     args_mock.return_value = Node(
-        name="test", version=None, verbose=True, include="", exclude="", url="test_url", token="test_token", method=CloneMethod.SSH, file=None, concurrency=1, disble_progress=True, print=None, dest=".")
+        name="test", version=None, verbose=True, include="", exclude="", url="test_url", token="test_token", method=CloneMethod.SSH, naming=FolderNaming.PATH, file=None, concurrency=1, disble_progress=True, print=None, dest=".")
     cli.parse_args = args_mock
 
     mock_streamhandler = mock.Mock()
@@ -53,7 +54,7 @@ def test_args_include(mock_tree):
     exc_groups = "/exc**,/exc**"
     args_mock = mock.Mock()
     args_mock.return_value = Node(
-        name="test", version=None, debug=None, include=inc_groups, exclude=exc_groups, url="test_url", token="test_token", method=CloneMethod.SSH, file=None, concurrency=1, disble_progress=True, print=None, dest=".")
+        name="test", version=None, debug=None, include=inc_groups, exclude=exc_groups, url="test_url", token="test_token", method=CloneMethod.SSH, naming=FolderNaming.NAME, file=None, concurrency=1, disble_progress=True, print=None, dest=".")
     cli.parse_args = args_mock
     
     split_mock = mock.Mock()
@@ -69,7 +70,7 @@ def test_args_include(mock_tree):
 def test_args_include(mock_tree):
     args_mock = mock.Mock()
     args_mock.return_value = Node(
-        name="test", version=None, verbose=None, include="", exclude="", url="test_url", token="test_token", method=CloneMethod.SSH, file=None, concurrency=1, disdisble_progress=True, print=True, dest=".", print_format=PrintFormat.YAML)
+        name="test", version=None, verbose=None, include="", exclude="", url="test_url", token="test_token", method=CloneMethod.SSH, naming=FolderNaming.NAME, file=None, concurrency=1, disble_progress=True, print=True, dest=".", print_format=PrintFormat.YAML)
     cli.parse_args = args_mock
 
     print_tree_mock = mock.Mock()
@@ -92,7 +93,7 @@ def test_validate_path():
 def test_empty_tree(mock_tree):
     args_mock = mock.Mock()
     args_mock.return_value = Node(
-        name="test", version=None, verbose=None, include="", exclude="", url="test_url", token="test_token", method=CloneMethod.SSH, file=None, concurrency=1, disble_progress=True, print=True, dest=".")
+        name="test", version=None, verbose=None, include="", exclude="", url="test_url", token="test_token", method=CloneMethod.SSH, naming=FolderNaming.NAME, file=None, concurrency=1, disble_progress=True, print=True, dest=".")
     cli.parse_args = args_mock
 
     with pytest.raises(SystemExit):

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,0 +1,13 @@
+from gitlabber.naming import FolderNaming
+import pytest
+
+def test_naming_parse():
+    assert FolderNaming.PATH == FolderNaming.argparse("PATH")
+
+def test_naming_string():
+    assert "name" == FolderNaming.__str__(FolderNaming.NAME)
+
+
+def test_naming_invalid():
+    assert "invalid_value" == FolderNaming.argparse("invalid_value")
+        


### PR DESCRIPTION
add support for folder naming strategy, allowing using either the project name or the project path values from the gitlab API.

Fix for #25 fix for #38, closes #39 