### PR TITLE
add support for archive flagging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,8 @@ Usage
                             the folder naming strategy for projects (default: "name")
     -m {ssh,http}, --method {ssh,http}
                             the git transport method to use for cloning (default: "ssh")
+    -a {include,exclude,only}, --archived {include,exclude,only}
+                            include archived projects and groups in the results (default: "include")
     -i csv, --include csv
                             comma delimited list of glob patterns of paths to projects or groups to clone/pull
     -x csv, --exclude csv

--- a/gitlabber/archive.py
+++ b/gitlabber/archive.py
@@ -1,0 +1,23 @@
+import enum
+
+class ArchivedResults(enum.Enum):
+    INCLUDE = (1, None)
+    EXCLUDE = (2, False)
+    ONLY = (3, True)
+
+    def __init__(self, int_value, api_value):
+        self.int_value = int_value
+        self.api_value = api_value 
+
+    def __str__(self):
+        return self.name.lower()
+
+    def __repr__(self):
+        return str(self)
+
+    @staticmethod
+    def argparse(s):
+        try:
+            return ArchivedResults[s.upper()]
+        except KeyError:
+            return s

--- a/gitlabber/cli.py
+++ b/gitlabber/cli.py
@@ -9,6 +9,7 @@ from .gitlab_tree import GitlabTree
 from .format import PrintFormat
 from .method import CloneMethod
 from .naming import FolderNaming
+from .archive import ArchivedResults
 from . import __version__ as VERSION
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -31,7 +32,8 @@ def main():
     config_logging(args)
     includes=split(args.include)
     excludes=split(args.exclude)
-    tree = GitlabTree(args.url, args.token, args.method, args.naming, includes,
+
+    tree = GitlabTree(args.url, args.token, args.method, args.naming, args.archived.api_value, includes,
                       excludes, args.file, args.concurrency, args.recursive, args.verbose)
     log.debug("Reading projects tree from gitlab at [%s]", args.url)
     tree.load_tree()
@@ -149,6 +151,13 @@ def parse_args(argv=None):
         choices=list(CloneMethod),
         default=os.environ.get('GITLABBER_CLONE_METHOD', "ssh"),
         help='the git transport method to use for cloning (default: "ssh")')
+    parser.add_argument(
+        '-a',
+        '--archived',
+        type=ArchivedResults.argparse,
+        choices=list(ArchivedResults),
+        default=ArchivedResults.INCLUDE,
+        help='include archived projects and groups in the results (default: "include")')
     parser.add_argument(
         '-i',
         '--include',

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,17 @@
+from gitlabber.archive import ArchivedResults
+import pytest
+
+def test_archive_parse():
+    assert ArchivedResults.INCLUDE == ArchivedResults.argparse("include")
+
+def test_archive_string():
+    assert "exclude" == ArchivedResults.__str__(ArchivedResults.EXCLUDE)
+
+def test_archive_api_value():
+    assert True == ArchivedResults.ONLY.api_value
+    assert False == ArchivedResults.EXCLUDE.api_value
+    assert None == ArchivedResults.INCLUDE.api_value
+
+def test_archive_invalid():
+    assert "invalid_value" == ArchivedResults.argparse("invalid_value")
+        

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,11 +1,16 @@
 from gitlabber.archive import ArchivedResults
 import pytest
+import re
 
 def test_archive_parse():
     assert ArchivedResults.INCLUDE == ArchivedResults.argparse("include")
 
 def test_archive_string():
     assert "exclude" == ArchivedResults.__str__(ArchivedResults.EXCLUDE)
+
+def test_repr():
+    retval = repr(ArchivedResults.ONLY)
+    match = re.match("^<ArchivedResults: ({.*})>\Z", retval)
 
 def test_archive_api_value():
     assert True == ArchivedResults.ONLY.api_value

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,19 +6,22 @@ import tests.output_test_utils as output_util
 from gitlabber.format import PrintFormat
 from gitlabber.method import CloneMethod
 from gitlabber.naming import FolderNaming
+from gitlabber.archive import ArchivedResults
 from unittest import mock
 from anytree import Node
 import pytest
+
 
 def exit():
     import sys
     sys.exit()
 
+
 def test_args_version():
     args_mock = mock.Mock()
-    args_mock.return_value = Node(name="test",version=True)
+    args_mock.return_value = Node(name="test", version=True)
     cli.parse_args = args_mock
-    
+
     with output_util.captured_output() as (out, err):
         with pytest.raises(SystemExit):
             cli.main()
@@ -33,7 +36,7 @@ def test_args_version():
 def test_args_logging(mock_tree, mock_log, mock_os, mock_sys, mock_logging):
     args_mock = mock.Mock()
     args_mock.return_value = Node(
-        name="test", version=None, verbose=True, include="", exclude="", url="test_url", token="test_token", method=CloneMethod.SSH, naming=FolderNaming.PATH, file=None, concurrency=1, recursive=False, disble_progress=True, print=None, dest=".")
+        name="test", version=None, verbose=True, include="", exclude="", url="test_url", token="test_token", method=CloneMethod.SSH, naming=FolderNaming.PATH, archived=ArchivedResults.INCLUDE, file=None, concurrency=1, recursive=False, disble_progress=True, print=None, dest=".")
     cli.parse_args = args_mock
 
     mock_streamhandler = mock.Mock()
@@ -54,13 +57,13 @@ def test_args_include(mock_tree):
     exc_groups = "/exc**,/exc**"
     args_mock = mock.Mock()
     args_mock.return_value = Node(
-        name="test", version=None, debug=None, include=inc_groups, exclude=exc_groups, url="test_url", token="test_token", method=CloneMethod.SSH, naming=FolderNaming.NAME, file=None, concurrency=1, recursive=False, disble_progress=True, print=None, dest=".")
+        name="test", version=None, debug=None, include=inc_groups, exclude=exc_groups, url="test_url", token="test_token", method=CloneMethod.SSH, naming=FolderNaming.NAME, archived=ArchivedResults.INCLUDE, file=None, concurrency=1, recursive=False, disble_progress=True, print=None, dest=".")
     cli.parse_args = args_mock
-    
+
     split_mock = mock.Mock()
     cli.split = split_mock
 
-    mock_tree.return_value.is_empty = mock.Mock(return_value = False)
+    mock_tree.return_value.is_empty = mock.Mock(return_value=False)
 
     cli.main()
     split_mock.assert_has_calls([mock.call(inc_groups), mock.call(exc_groups)])
@@ -70,7 +73,7 @@ def test_args_include(mock_tree):
 def test_args_include(mock_tree):
     args_mock = mock.Mock()
     args_mock.return_value = Node(
-        name="test", version=None, verbose=None, include="", exclude="", url="test_url", token="test_token", method=CloneMethod.SSH, naming=FolderNaming.NAME, file=None, concurrency=1, recursive=False, disble_progress=True, print=True, dest=".", print_format=PrintFormat.YAML)
+        name="test", version=None, verbose=None, include="", exclude="", url="test_url", token="test_token", method=CloneMethod.SSH, naming=FolderNaming.NAME, archived=ArchivedResults.INCLUDE, file=None, concurrency=1, recursive=False, disble_progress=True, print=True, dest=".", print_format=PrintFormat.YAML)
     cli.parse_args = args_mock
 
     print_tree_mock = mock.Mock()
@@ -80,6 +83,7 @@ def test_args_include(mock_tree):
     cli.main()
 
     print_tree_mock.assert_called_once_with(PrintFormat.YAML)
+
 
 def test_validate_path():
     assert "/test" == cli.validate_path("/test/")
@@ -93,7 +97,7 @@ def test_validate_path():
 def test_empty_tree(mock_tree):
     args_mock = mock.Mock()
     args_mock.return_value = Node(
-        name="test", version=None, verbose=None, include="", exclude="", url="test_url", token="test_token", method=CloneMethod.SSH, naming=FolderNaming.NAME, file=None, concurrency=1, recursive=False, disble_progress=True, print=True, dest=".")
+        name="test", version=None, verbose=None, include="", exclude="", url="test_url", token="test_token", method=CloneMethod.SSH, naming=FolderNaming.NAME, archived=ArchivedResults.INCLUDE, file=None, concurrency=1, recursive=False, disble_progress=True, print=True, dest=".")
     cli.parse_args = args_mock
 
     with pytest.raises(SystemExit):
@@ -104,7 +108,7 @@ def test_empty_tree(mock_tree):
 def test_missing_dest(mock_tree, capsys):
     args_mock = mock.Mock()
     args_mock.return_value = Node(
-        name="test", version=None, verbose=None, include="", exclude="", url="test_url", token="test_token", method=CloneMethod.SSH, naming=FolderNaming.NAME, file=None, concurrency=1, recursive=False, disble_progress=True, print=False, dest=None)
+        name="test", version=None, verbose=None, include="", exclude="", url="test_url", token="test_token", method=CloneMethod.SSH, naming=FolderNaming.NAME, archived=ArchivedResults.INCLUDE, file=None, concurrency=1, recursive=False, disble_progress=True, print=False, dest=None)
     cli.parse_args = args_mock
     mock_tree.return_value.is_empty = mock.Mock(return_value=False)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,7 +92,25 @@ def test_validate_path():
     assert "." == cli.validate_path("./")
     assert "." == cli.validate_path(".")
 
+@mock.patch("gitlabber.cli.GitlabTree")
+def test__missing_token(mock_tree):
+    args_mock = mock.Mock()
+    args_mock.return_value = Node(
+        name="test", version=None, verbose=None, include="", exclude="", url="test_url", token=None, print=True, dest=".")
+    cli.parse_args = args_mock
 
+    with pytest.raises(SystemExit):
+        cli.main()
+
+@mock.patch("gitlabber.cli.GitlabTree")
+def test_missing_url(mock_tree):
+    args_mock = mock.Mock()
+    args_mock.return_value = Node(
+        name="test", version=None, verbose=None, include="", exclude="", url=None, token="some_token", print=True, dest=".")
+    cli.parse_args = args_mock
+
+    with pytest.raises(SystemExit):
+        cli.main()
 @mock.patch("gitlabber.cli.GitlabTree")
 def test_empty_tree(mock_tree):
     args_mock = mock.Mock()

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -1,5 +1,6 @@
 from gitlabber.format import PrintFormat
 import pytest
+import re
 
 def test_format_parse():
     assert PrintFormat.JSON == PrintFormat.argparse("JSON")
@@ -7,6 +8,9 @@ def test_format_parse():
 def test_format_string():
     assert "json" == PrintFormat.__str__(PrintFormat.JSON)
 
+def test_repr():
+    retval = repr(PrintFormat.JSON)
+    match = re.match("^<PrintFormat: ({.*})>\Z", retval)
 
 def test_format_invalid():
     assert "invalid_value" == PrintFormat.argparse("invalid_value")

--- a/tests/test_method.py
+++ b/tests/test_method.py
@@ -1,11 +1,16 @@
 from gitlabber.method import CloneMethod
 import pytest
+import re
 
 def test_method_parse():
     assert CloneMethod.SSH == CloneMethod.argparse("ssh")
 
 def test_method_string():
     assert "http" == CloneMethod.__str__(CloneMethod.HTTP)
+
+def test_repr():
+    retval = repr(CloneMethod.SSH)
+    match = re.match("^<CloneMethod: ({.*})>\Z", retval)
 
 
 def test_method_invalid():

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -1,5 +1,6 @@
 from gitlabber.naming import FolderNaming
 import pytest
+import re
 
 def test_naming_parse():
     assert FolderNaming.PATH == FolderNaming.argparse("PATH")
@@ -7,6 +8,9 @@ def test_naming_parse():
 def test_naming_string():
     assert "name" == FolderNaming.__str__(FolderNaming.NAME)
 
+def test_repr():
+    retval = repr(FolderNaming.PATH)
+    match = re.match("^<FolderNaming: ({.*})>\Z", retval)
 
 def test_naming_invalid():
     assert "invalid_value" == FolderNaming.argparse("invalid_value")


### PR DESCRIPTION
add support for archive flagging using python-gitlab flag which allows including archived projects (none),  omitting archived projects (false) and fetching only archived projects (true)

Fixes #47 