### PR TITLE
Reduce the number of scanned projects when possible

### DIFF
--- a/tests/gitlab_test_utils.py
+++ b/tests/gitlab_test_utils.py
@@ -40,7 +40,7 @@ class Listable:
         self.get_result = get_result
         self.archive_result = archive_result
 
-    def list(self, as_list=False, archived=None):
+    def list(self, as_list=False, archived=None, search=None):
         if archived is None:
             return [self.list_result, self.archive_result] if self.archive_result is not None else [self.list_result]
         elif archived is True:


### PR DESCRIPTION
Closes #68

The current implementation doesn't add any option and piggybacks on `--include`.

When there's only one include and it looks like a top level group, use the search feature of gitlab instead of blindly list all groups, subgroups and projects.