### PR TITLE
Avoid 404 errors for groups we can see but not access

### DIFF
--- a/gitlabber/gitlab_tree.py
+++ b/gitlabber/gitlab_tree.py
@@ -58,7 +58,7 @@ class GitlabTree:
 
     def is_excluded(self, node):
         '''
-        returns True if the node should be excluded 
+        returns True if the node should be excluded
         if the are no exclude patterns then nothing is excluded
         any exclude pattern matching the root path will result in exclusion
         '''
@@ -113,7 +113,11 @@ class GitlabTree:
             try:
                 subgroup = self.gitlab.groups.get(subgroup_def.id)
             except GitlabGetError as error:
-                log.warning(f"Group {subgroup.name} (ID: {subgroup.id}) retrieval error: {error}")
+                if error.response_code == 404:
+                    log.error(f"""Error retrieving group {subgroup.name} (ID: {subgroup.id}): {error.response_body}.
+                                  Check your permissions as you may not have access to it.""")
+                else:
+                    log.error(f"Error retrieving group: {subgroup.name} (ID: {subgroup.id}): {error.response_body}")
                 continue
             subgroup_id = subgroup.name if self.naming == FolderNaming.NAME else subgroup.path
             node = self.make_node(subgroup_id, parent, url=subgroup.web_url)

--- a/gitlabber/gitlab_tree.py
+++ b/gitlabber/gitlab_tree.py
@@ -114,10 +114,9 @@ class GitlabTree:
                 subgroup = self.gitlab.groups.get(subgroup_def.id)
             except GitlabGetError as error:
                 if error.response_code == 404:
-                    log.error(f"""Error retrieving group {subgroup.name} (ID: {subgroup.id}): {error.response_body}.
-                                  Check your permissions as you may not have access to it.""")
+                    log.error(f"Error retrieving group {subgroup.name} (ID: {subgroup.id}): {error}. Check your permissions as you may not have access to it.")
                 else:
-                    log.error(f"Error retrieving group: {subgroup.name} (ID: {subgroup.id}): {error.response_body}")
+                    log.error(f"Error retrieving group: {subgroup.name} (ID: {subgroup.id}): {error}")
                 continue
             subgroup_id = subgroup.name if self.naming == FolderNaming.NAME else subgroup.path
             node = self.make_node(subgroup_id, parent, url=subgroup.web_url)

--- a/gitlabber/gitlab_tree.py
+++ b/gitlabber/gitlab_tree.py
@@ -115,9 +115,10 @@ class GitlabTree:
             except GitlabGetError as error:
                 if error.response_code == 404:
                     log.error(f"Error retrieving group {subgroup.name} (ID: {subgroup.id}): {error}. Check your permissions as you may not have access to it.")
+                    continue
                 else:
                     log.error(f"Error retrieving group: {subgroup.name} (ID: {subgroup.id}): {error}")
-                continue
+                    raise error
             subgroup_id = subgroup.name if self.naming == FolderNaming.NAME else subgroup.path
             node = self.make_node(subgroup_id, parent, url=subgroup.web_url)
             self.progress.show_progress(node.name, 'group')

--- a/gitlabber/gitlab_tree.py
+++ b/gitlabber/gitlab_tree.py
@@ -1,5 +1,5 @@
 from gitlab import Gitlab
-from gitlab.exceptions import GitlabGetError
+from gitlab.exceptions import GitlabGetError, GitlabListError
 from anytree import Node, RenderTree
 from anytree.exporter import DictExporter, JsonExporter
 from anytree.importer import DictImporter
@@ -107,7 +107,12 @@ class GitlabTree:
         self.add_projects(parent, projects)
 
     def get_subgroups(self, group, parent):
-        subgroups = group.subgroups.list(as_list=False, archived=self.archived)
+        try:
+            subgroups = group.subgroups.list(as_list=False, archived=self.archived)
+        except GitlabListError as error:
+            log.error(f"Error listing group {group.name} (ID: {group.id}): {error}. Check your permissions as you may not have access to it.")
+            return
+
         self.progress.update_progress_length(len(subgroups))
         for subgroup_def in subgroups:
             try:

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -102,6 +102,21 @@ def test_pull_repo_recursive(mock_git):
     repo_instance.submodule_update.assert_called_once_with(recursive=True)
 
 @mock.patch('gitlabber.git.git')
+def test_pull_repo_exception(mock_git):
+    mock_repo = mock.Mock()
+    mock_git.Repo = mock_repo
+    git.is_git_repo = mock.MagicMock(return_value=True)
+
+    repo_instance = mock_git.Repo.return_value
+    repo_instance.remotes.origin.pull.side_effect=Exception('pull test exception')
+
+    git.clone_or_pull_project(GitAction(
+        Node(name="dummy_url", url="dummy_url"), "dummy_dir"))
+
+    mock_git.Repo.assert_called_once_with("dummy_dir")
+    repo_instance.remotes.origin.pull.assert_called_once()
+
+@mock.patch('gitlabber.git.git')
 def test_pull_repo_interrupt(mock_git):
     mock_repo = mock.Mock()
     mock_git.Repo = mock_repo


### PR DESCRIPTION
Fixed an uncaught exception that was caused when the tree is generating and we see a group we can't access. We tried to retrieve it's info but it raised an exception and that made the script fail completely (even if the group wasn't part of the `-i` flag.)

I've catched the exception and logged the error for the user to notice.