### PR TITLE
Gitlab 500 Error when accessing "Gitlab Instance" while listing projects

### DIFF
--- a/gitlabber/gitlab_tree.py
+++ b/gitlabber/gitlab_tree.py
@@ -1,4 +1,4 @@
-from gitlab import Gitlab
+from gitlab import Gitlab, GitlabListError
 from anytree import Node, RenderTree
 from anytree.exporter import DictExporter, JsonExporter
 from anytree.importer import DictImporter
@@ -124,6 +124,9 @@ class GitlabTree:
                 group_id = group.name if self.naming == FolderNaming.NAME else group.path
                 node = self.make_node(group_id, self.root, url=group.web_url)
                 self.progress.show_progress(node.name, 'group')
+                # Fix: https://gitlab.com/gitlab-org/gitlab/-/issues/292682
+                if group_id == 'GitLab Instance':
+                    continue
                 self.get_subgroups(group, node)
                 self.get_projects(group, node)
 

--- a/gitlabber/gitlab_tree.py
+++ b/gitlabber/gitlab_tree.py
@@ -1,4 +1,4 @@
-from gitlab import Gitlab, GitlabListError
+from gitlab import Gitlab
 from anytree import Node, RenderTree
 from anytree.exporter import DictExporter, JsonExporter
 from anytree.importer import DictImporter


### PR DESCRIPTION
GitlabListError/Error 500 when trying to list Gitlab internal projects in "GitLab Instance" group


