### PR TITLE
Fix gitlab.exceptions.GitlabListError: 404: 404 Group Not Found

### DIFF
--- a/gitlabber/gitlab_tree.py
+++ b/gitlabber/gitlab_tree.py
@@ -136,14 +136,13 @@ class GitlabTree:
                     self.get_projects(subgroup, node)
                 except GitlabGetError as error:
                     if error.response_code == 404:
-                        log.error(f"{error.response_code} error while get subgroup with name: {group.name} [id: {group.id}]. Check your permissions as you may not have access to it. Message: {error.error_message}")
+                        log.error(f"{error.response_code} error while getting subgroup with name: {group.name} [id: {group.id}]. Check your permissions as you may not have access to it. Message: {error.error_message}")
                         continue
                     else:
                         raise error
         except GitlabListError as error:
             if error.response_code == 404:
-                log.error(f"{error.response_code} error while list subgroup with name: {group.name} [id: {group.id}]. Check your permissions as you may not have access to it. Message: {error.error_message}")
-                pass
+                log.error(f"{error.response_code} error while listing subgroup with name: {group.name} [id: {group.id}]. Check your permissions as you may not have access to it. Message: {error.error_message}")
             else:
                 raise error
 


### PR DESCRIPTION
# Bugfix for 404 Group Not Found

This is a bugfix as i recieve and Errormessage like this. This PR helps me go download all my required projects.

When trying to download repos with gitlabber i get an error like this. There are loads of repos on group on this gitlab installation:

```
2025-01-02 12:18:21,883 - urllib3.connectionpool - DEBUG - https://gitlabhost:443 "GET /api/v4/groups/15871/subgroups?as_list=False HTTP/11" 200 2
2025-01-02 12:18:22,067 - urllib3.connectionpool - DEBUG - https://gitlabhost:443 "GET /api/v4/groups/15871/projects?archived=False&with_shared=True HTTP/11" 200 None
2025-01-02 12:18:22,205 - urllib3.connectionpool - DEBUG - https://gitlabhost:443 "GET /api/v4/groups/4174/projects?archived=False&with_shared=True HTTP/11" 200 None
2025-01-02 12:18:22,248 - urllib3.connectionpool - DEBUG - https://gitlabhost:443 "GET /api/v4/groups/12778/subgroups?as_list=False HTTP/11" 404 33
Traceback (most recent call last):
  File "/home/leneffets/.local/lib/python3.11/site-packages/gitlab/exceptions.py", line 344, in wrapped_f
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/home/leneffets/.local/lib/python3.11/site-packages/gitlab/mixins.py", line 247, in list
    obj = self.gitlab.http_list(path, **data)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/leneffets/.local/lib/python3.11/site-packages/gitlab/client.py", line 905, in http_list
    return list(GitlabList(self, url, query_data, **kwargs))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/leneffets/.local/lib/python3.11/site-packages/gitlab/client.py", line 1177, in __init__
    self._query(url, query_data, **self._kwargs)
  File "/home/leneffets/.local/lib/python3.11/site-packages/gitlab/client.py", line 1187, in _query
    result = self._gl.http_request("get", url, query_data=query_data, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/leneffets/.local/lib/python3.11/site-packages/gitlab/client.py", line 773, in http_request
    raise gitlab.exceptions.GitlabHttpError(
gitlab.exceptions.GitlabHttpError: 404: 404 Group Not Found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/leneffets/.local/bin/gitlabber", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/leneffets/.local/lib/python3.11/site-packages/gitlabber/cli.py", line 48, in main
    tree.load_tree()
  File "/home/leneffets/.local/lib/python3.11/site-packages/gitlabber/gitlab_tree.py", line 184, in load_tree
    self.load_gitlab_tree()
  File "/home/leneffets/.local/lib/python3.11/site-packages/gitlabber/gitlab_tree.py", line 153, in load_gitlab_tree
    self.get_subgroups(group, node)
  File "/home/leneffets/.local/lib/python3.11/site-packages/gitlabber/gitlab_tree.py", line 126, in get_subgroups
    subgroups = group.subgroups.list(as_list=False, get_all=True)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/leneffets/.local/lib/python3.11/site-packages/gitlab/exceptions.py", line 346, in wrapped_f
    raise error(e.error_message, e.response_code, e.response_body) from e
gitlab.exceptions.GitlabListError: 404: 404 Group Not Found

```

I modified the `get_subgroup` func to handle that exception. 

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested it on my client. All existing tests were successful.

# Checklist:

- [x ] I have performed a self-review of my code
- [x ] My changes generate no new warnings and do not breat any existing tests
- [x ] New and existing unit tests pass locally with my changes
- [x ] Any dependent changes have been merged and published in downstream modules

