### PR TITLE
add support for group.shared_projects API from gitlab

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,7 +119,6 @@ Usage
                             comma delimited list of glob patterns of paths to projects or groups to exclude from clone/pull
     -r, --recursive       clone/pull git submodules recursively
     -F, --use-fetch       clone/fetch git repository (mirrored repositories)
-    -d, --dont-checkout   don't checkout pulled git repository
     -s, --include-shared  include shared projects in the results
     -g term, --group-search term
                             only include groups matching the search term, filtering done at the API level (useful for large projects, see: https://docs.gitlab.com/ee/api/groups.html#search-for-group works with partial names of path or name)
@@ -148,7 +147,7 @@ Usage
         clone projects that start with a case insensitive 'w' using a regular expression:
         gitlabber -i '/{[w].*}' .
 
-        clone a user's personal projects to username-personal-projects
+        clone the personal projects to username-personal-projects
         gitlabber -U .
 
         perform a shallow clone of the git repositories

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -119,7 +119,6 @@ Usage
                             comma delimited list of glob patterns of paths to projects or groups to exclude from clone/pull
     -r, --recursive       clone/pull git submodules recursively
     -F, --use-fetch       clone/fetch git repository (mirrored repositories)
-    -d, --dont-checkout   don't checkout pulled git repository
     -s, --include-shared  include shared projects in the results
     -g term, --group-search term
                             only include groups matching the search term, filtering done at the API level (useful for large projects, see: https://docs.gitlab.com/ee/api/groups.html#search-for-group works with partial names of path or name)
@@ -148,7 +147,7 @@ Usage
         clone projects that start with a case insensitive 'w' using a regular expression:
         gitlabber -i '/{[w].*}' .
 
-        clone a user's personal projects to username-personal-projects
+        clone the user personal projects to username-personal-projects
         gitlabber -U .
 
         perform a shallow clone of the git repositories

--- a/gitlabber/cli.py
+++ b/gitlabber/cli.py
@@ -92,7 +92,7 @@ def parse_args(argv=None):
     clone projects that start with a case insensitive 'w' using a regular expression:
     gitlabber -i '/{[w].*}' .
     
-    clone a user's personal projects to username-personal-projects
+    clone the user personal projects to username-personal-projects
     gitlabber -U .
     
     perform a shallow clone of the git repositories
@@ -199,12 +199,6 @@ def parse_args(argv=None):
         action='store_true',
         default=False,
         help='clone/fetch git repository (mirrored repositories)')
-    parser.add_argument(
-        '-d',
-        '--dont-checkout',
-        action='store_true',
-        default=False,
-        help="don't checkout pulled git repository")    
     parser.add_argument(
         '-s',
         '--include-shared',

--- a/gitlabber/gitlab_tree.py
+++ b/gitlabber/gitlab_tree.py
@@ -119,6 +119,11 @@ class GitlabTree:
             projects = group.projects.list(archived=self.archived, with_shared=self.include_shared, get_all=True)
             self.progress.update_progress_length(len(projects))
             self.add_projects(parent, projects)
+            
+            if self.include_shared and hasattr(group, 'shared_projects'):
+                shared_projects = group.shared_projects.list(get_all=True)
+                self.progress.update_progress_length(len(shared_projects))
+                self.add_projects(parent, shared_projects)
         except GitlabListError as error:
             log.error(f"Error getting projects on {group.name} id: [{group.id}]  error message: [{error.error_message}]")
 

--- a/tests/gitlab_test_utils.py
+++ b/tests/gitlab_test_utils.py
@@ -23,7 +23,7 @@ TREE_TEST_OUTPUT_FILE = "tests/test-output.tree"
 
 
 class MockNode:
-    def __init__(self, type, id, name, url, subgroups=mock.MagicMock(), projects=mock.MagicMock(), parent_id=None, archived=0, shared=False, group_search=None, git_options=None):
+    def __init__(self, type, id, name, url, subgroups=mock.MagicMock(), projects=mock.MagicMock(), shared_projects=mock.MagicMock(), parent_id=None, archived=0, shared=False, group_search=None, git_options=None):
         self.type = type
         self.id = id
         self.name = name
@@ -34,6 +34,7 @@ class MockNode:
         self.http_url_to_repo = url
         self.subgroups = subgroups
         self.projects = projects
+        self.shared_projects = shared_projects
         self.parent_id = parent_id
         self.archived = archived
         self.shared = shared
@@ -174,9 +175,12 @@ def create_test_gitlab_with_shared(monkeypatch, includes=None, excludes=None, in
 
     projects = Listable(
         MockNode("project", 19, PROJECT_NAME, PROJECT_URL),
+    )
+     
+    shared_projects = Listable(
         MockNode("project", 20, "_shared_" + PROJECT_NAME, "_shared_" + PROJECT_URL, shared=True)
     )
     monkeypatch.setattr(gl.gitlab, "groups", Tree(Listable(
-        MockNode("group", 21, GROUP_NAME, GROUP_URL, projects=projects)
+        MockNode("group", 21, GROUP_NAME, GROUP_URL, projects=projects, shared_projects=shared_projects)
     )))
     return gl

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -11,7 +11,7 @@ coverage.process_startup()
 @pytest.mark.slow_integration_test
 def test_clone_subgroup():
     os.environ['GITLAB_URL'] = 'https://gitlab.com/'
-    output = io_util.execute(['-p', '--print-format', 'json', '--group-search', 'Group Test'], 60)
+    output = io_util.execute(['-p', '--print-format', 'json', '--group-search', 'Group Test'], 90)
     obj = json.loads(output)
     assert obj['children'][0]['name'] == 'Group Test'
     assert obj['children'][0]['children'][0]['name'] == 'Subgroup Test'
@@ -23,7 +23,7 @@ def test_clone_subgroup():
 @pytest.mark.slow_integration_test
 def test_clone_subgroup_exclude_archived():
     os.environ['GITLAB_URL'] = 'https://gitlab.com/'
-    output = io_util.execute(['-p', '--print-format', 'json', '--group-search', 'Group Test',  '-a', 'exclude'], 60)
+    output = io_util.execute(['-p', '--print-format', 'json', '--group-search', 'Group Test',  '-a', 'exclude'], 90)
     obj = json.loads(output)
     assert obj['children'][0]['name'] == 'Group Test'
     assert obj['children'][0]['children'][0]['name'] == 'Subgroup Test'
@@ -34,7 +34,7 @@ def test_clone_subgroup_exclude_archived():
 @pytest.mark.slow_integration_test
 def test_clone_subgroup_only_archived():
     os.environ['GITLAB_URL'] = 'https://gitlab.com/'
-    output = io_util.execute(['-p', '--print-format', 'json', '--group-search', 'Group Test',  '-a', 'only'], 60)
+    output = io_util.execute(['-p', '--print-format', 'json', '--group-search', 'Group Test',  '-a', 'only'], 90)
     obj = json.loads(output)
     assert obj['children'][0]['name'] == 'Group Test'
     assert obj['children'][0]['children'][0]['name'] == 'Subgroup Test'
@@ -45,7 +45,7 @@ def test_clone_subgroup_only_archived():
 @pytest.mark.slow_integration_test
 def test_clone_subgroup_naming_path():
     os.environ['GITLAB_URL'] = 'https://gitlab.com/'
-    output = io_util.execute(['-p', '--print-format', 'json', '-n', 'path', '--group-search', 'Group Test'], 60)
+    output = io_util.execute(['-p', '--print-format', 'json', '-n', 'path', '--group-search', 'Group Test'], 90)
     obj = json.loads(output)
     assert obj['children'][0]['name'] == 'erez-group-test'
     assert obj['children'][0]['children'][0]['name'] == 'subgroup-test'
@@ -58,7 +58,7 @@ def test_clone_subgroup_naming_path():
 @pytest.mark.slow_integration_test
 def test_large_groups():
     os.environ['GITLAB_URL'] = 'https://gitlab.com/'
-    output = io_util.execute(['-p', '--print-format', 'json', '-n', 'path', '--group-search', 'large-group-test'], 60)
+    output = io_util.execute(['-p', '--print-format', 'json', '-n', 'path', '--group-search', 'large-group-test'], 90)
     obj = json.loads(output)
     assert obj['children'][0]['name'] == 'large-group-test'
     assert obj['children'][0]['children'][0]['name'] == 'many-subgroups'
@@ -70,7 +70,7 @@ def test_large_groups():
 @pytest.mark.slow_integration_test
 def test_user_personal_projects():
     os.environ['GITLAB_URL'] = 'https://gitlab.com/'
-    output = io_util.execute(['-p', '--print-format', 'json', '-n', 'path', '--user-projects'], 60)
+    output = io_util.execute(['-p', '--print-format', 'json', '-n', 'path', '--user-projects'], 90)
     obj = json.loads(output)
     assert obj['children'][0]['name'] == 'erezmazor-prsonal-projects'
     assert obj['children'][0]['children'][0]['name'] == 'gitlabber-personal-project'
@@ -79,7 +79,7 @@ def test_user_personal_projects():
 @pytest.mark.slow_integration_test
 def test_shared_group_and_project():
     os.environ['GITLAB_URL'] = 'https://gitlab.com/'
-    output = io_util.execute(['-p', '--print-format', 'json', '-s', '--group-search', 'shared-group3'], 60)
+    output = io_util.execute(['-p', '--print-format', 'json', '-s', '--group-search', 'shared-group3'], 90)
     obj = json.loads(output)
     assert obj['children'][0]['name'] == 'Shared Group'
     assert obj['children'][0]['children'][0]['name'] == 'Shared Project'

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -75,3 +75,13 @@ def test_user_personal_projects():
     assert obj['children'][0]['name'] == 'erezmazor-prsonal-projects'
     assert obj['children'][0]['children'][0]['name'] == 'gitlabber-personal-project'
     
+
+@pytest.mark.slow_integration_test
+def test_shared_group_and_project():
+    os.environ['GITLAB_URL'] = 'https://gitlab.com/'
+    output = io_util.execute(['-p', '--print-format', 'json', '-s', '--group-search', 'shared-group3'], 60)
+    obj = json.loads(output)
+    assert obj['children'][0]['name'] == 'Shared Group'
+    assert obj['children'][0]['children'][0]['name'] == 'Shared Project'
+    
+    


### PR DESCRIPTION
# Description

Add support for `groups.shared_group` from python-giltab (https://python-gitlab.readthedocs.io/en/stable/gl_objects/groups.html) to support the `-s` flag

Fixes #140

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and specify the type of test (unit, integration, e2e)

- [ ] New integration test for shared groups `test_shared_group_and_project`
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings and do not break any existing tests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

