### PR TITLE
v2.1.1: Fix the mirror / use_fetch issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 <!--next-version-placeholder-->
 ## [Unreleased]
 
+## [2.1.1] - 2025-12-17
+
+### Fixed
+- **Fixed `--use-fetch` creating bare repositories**: The `--use-fetch` flag now correctly creates normal repositories with a working tree, instead of bare mirror repositories. This fixes the regression introduced in PR #100 where `--use-fetch` was incorrectly using `--mirror` during clone operations.
+- **Added `--mirror` flag for backup use cases**: Introduced a new `--mirror` flag specifically for creating bare mirror repositories (for backup purposes). The `--mirror` flag automatically uses `fetch` instead of `pull` for updates, preserving the original backup functionality while fixing the `--use-fetch` behavior.
+
+### Changed
+- **Separated concerns between `--use-fetch` and `--mirror`**: 
+  - `--use-fetch`: Creates normal repositories with working tree, uses `fetch` instead of `pull` for updates
+  - `--mirror`: Creates bare mirror repositories for backups, automatically uses `fetch` for updates
+- Updated documentation to clarify the difference between the two flags
+
+### Added
+- Comprehensive test coverage for all flag combinations to ensure `--use-fetch` and `--mirror` work correctly together without conflicts
+
+Fixes [#158](https://github.com/ezbz/gitlabber/issues/158)
+
 ## [2.1.0] - 2025-11-19
 
 ### Added

--- a/gitlabber/__init__.py
+++ b/gitlabber/__init__.py
@@ -5,4 +5,4 @@ while maintaining the directory structure. It supports filtering, progress
 tracking, and various configuration options.
 """
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'


### PR DESCRIPTION
## Issue Fixed in v2.1.1

This issue has been fixed in version **2.1.1**. Here's what happened and how it was resolved:

### Root Cause

The bug was introduced in [PR #100](https://github.com/ezbz/gitlabber/pull/100) which added support for the `--use-fetch` flag. The original implementation incorrectly added the `--mirror` flag to git clone operations whenever `--use-fetch` was enabled. This caused all repositories cloned with `--use-fetch` to be created as bare repositories (mirrors) instead of normal repositories with a working tree.

### The Fix

The fix separates the concerns of two different use cases:

1. **`--use-fetch` flag**: For users who want normal repositories (with working tree) but prefer using `git fetch` instead of `git pull` for updates. This is useful when you have local branches that no longer exist on the remote.

2. **`--mirror` flag** (new): For users who want bare mirror repositories for backup purposes. This automatically uses `fetch` instead of `pull` for updates, as mirrors should always use fetch.

### Changes Made

- **Removed** the automatic `--mirror` flag from `--use-fetch` clone operations
- **Added** a new `--mirror` flag specifically for creating bare mirror repositories
- **Updated** the `pull` method to check both `use_fetch` and `mirror` flags (mirror implies use_fetch)
- **Added** comprehensive test coverage to ensure both flags work correctly together

### Usage

**For normal repositories with fetch updates:**
```bash
gitlabber --use-fetch -t <token> -u <url> .
```

**For bare mirror repositories (backups):**
```bash
gitlabber --mirror -t <token> -u <url> .
```

### Testing

All flag combinations have been thoroughly tested:
- ✅ `--use-fetch` alone: normal repo, uses fetch
- ✅ `--mirror` alone: bare repo, uses fetch  
- ✅ Both flags: bare repo (mirror takes precedence), uses fetch
- ✅ Neither flag: normal repo, uses pull

The fix is available in **v2.1.1** and has been tested to ensure backward compatibility while fixing the reported issue.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes `--use-fetch` creating bare repos, adds `--mirror` for backups, updates docs/tests, and bumps version to 2.1.1.
> 
> - **CLI behavior**:
>   - Fix `--use-fetch` to create normal repos (no bare mirror cloning).
>   - Add `--mirror` flag for bare mirror backups; implies using `fetch` for updates.
>   - Clarify separation: `--use-fetch` (normal repos + fetch) vs `--mirror` (bare mirror + fetch).
> - **Docs**: Update to explain differences between `--use-fetch` and `--mirror`.
> - **Tests**: Add comprehensive coverage for flag combinations and interactions.
> - **Release**: Bump version to `2.1.1` and update `CHANGELOG.md` (fixes #158).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d2d5a673c822c1445808ce466b43438ab4deae1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->