### PR TITLE
v2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ options:
                         number of concurrent git operations (default: 1)
 --api-concurrency N    number of concurrent API calls for tree building (default: 5)
 -r, --recursive       clone/pull git submodules recursively
--F, --use-fetch       clone/fetch git repository (mirrored repositories)
+-F, --use-fetch       use git fetch instead of pull for updates (normal repositories with working tree)
+--mirror              create bare mirror repositories (for backups, automatically uses fetch)
 -s, --include-shared  include shared projects in the results
 -g term, --group-search term
                         only include groups matching the search term, filtering done at the API level
@@ -202,8 +203,6 @@ gitlabber --store-token -u https://gitlab.com
 # Use stored token (no -t flag needed)
 gitlabber -u https://gitlab.com .
 ```
-<｜tool▁call▁begin｜>
-run_terminal_cmd
 
 ## Common Use Cases
 

--- a/README.rst
+++ b/README.rst
@@ -189,7 +189,8 @@ Usage
                             number of concurrent git operations (default: 1)
     --api-concurrency N    number of concurrent API calls for tree building (default: 5)
     -r, --recursive       clone/pull git submodules recursively
-    -F, --use-fetch       clone/fetch git repository (mirrored repositories)
+    -F, --use-fetch       use git fetch instead of pull for updates (normal repositories with working tree)
+    --mirror              create bare mirror repositories (for backups, automatically uses fetch)
     -s, --include-shared  include shared projects in the results
     -g term, --group-search term
                             only include groups matching the search term, filtering done at the API level (useful for large projects, see: https://docs.gitlab.com/ee/api/groups.html#search-for-group works with partial names of path or name)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -189,7 +189,8 @@ Usage
                             number of concurrent git operations (default: 1)
     --api-concurrency N    number of concurrent API calls for tree building (default: 5)
     -r, --recursive       clone/pull git submodules recursively
-    -F, --use-fetch       clone/fetch git repository (mirrored repositories)
+    -F, --use-fetch       use git fetch instead of pull for updates (normal repositories with working tree)
+    --mirror              create bare mirror repositories (for backups, automatically uses fetch)
     -s, --include-shared  include shared projects in the results
     -g term, --group-search term
                             only include groups matching the search term, filtering done at the API level (useful for large projects, see: https://docs.gitlab.com/ee/api/groups.html#search-for-group works with partial names of path or name)

--- a/gitlabber/cli.py
+++ b/gitlabber/cli.py
@@ -211,6 +211,7 @@ def run_gitlabber(
     exclude: Optional[str],
     recursive: bool,
     use_fetch: bool,
+    mirror: bool,
     include_shared: bool,
     group_search: Optional[str],
     user_projects: bool,
@@ -244,6 +245,7 @@ def run_gitlabber(
         exclude: Comma-separated glob patterns to exclude
         recursive: Clone submodules recursively
         use_fetch: Use git fetch instead of pull
+        mirror: Create bare mirror repositories (implies use_fetch)
         include_shared: Include shared projects
         group_search: Search term for filtering groups at API level
         user_projects: Fetch only user personal projects
@@ -295,6 +297,7 @@ def run_gitlabber(
             "recursive": recursive,
             "include_shared": include_shared,
             "use_fetch": use_fetch,
+            "mirror": mirror,
             "hide_token": hide_token,
             "user_projects": user_projects,
             "group_search": group_search,
@@ -318,6 +321,7 @@ def run_gitlabber(
         disable_progress=verbose,
         include_shared=include_shared,
         use_fetch=use_fetch,
+        mirror=mirror,
         hide_token=hide_token,
         user_projects=user_projects,
         group_search=group_search,
@@ -458,7 +462,7 @@ def cli(
         False,
         "-F",
         "--use-fetch",
-        help="Use git fetch instead of pull (mirrored repositories)",
+        help="Use git fetch instead of pull for updates (normal repositories with working tree)",
     ),
     exclude_shared: bool = typer.Option(
         False,
@@ -494,6 +498,11 @@ def cli(
         False,
         "--store-token",
         help="Store token securely in OS keyring (requires keyring package)",
+    ),
+    mirror: bool = typer.Option(
+        False,
+        "--mirror",
+        help="Create bare mirror repositories (for backups, automatically uses fetch)",
     ),
 ) -> None:
     """Main CLI command for gitlabber.
@@ -560,6 +569,7 @@ def cli(
         exclude=exclude,
         recursive=recursive,
         use_fetch=use_fetch,
+        mirror=mirror,
         include_shared=include_shared_value,
         group_search=group_search,
         user_projects=user_projects,

--- a/gitlabber/config.py
+++ b/gitlabber/config.py
@@ -80,6 +80,7 @@ class GitlabberConfig(BaseModel):
     disable_progress: bool = False
     include_shared: bool = True
     use_fetch: bool = False
+    mirror: bool = False
     hide_token: bool = False
     user_projects: bool = False
     group_search: Optional[str] = None

--- a/gitlabber/gitlab_tree.py
+++ b/gitlabber/gitlab_tree.py
@@ -45,6 +45,7 @@ class GitlabTree:
                  disable_progress: bool = False,
                  include_shared: bool = True,
                  use_fetch: bool = False,
+                 mirror: bool = False,
                  hide_token: bool = False,
                  user_projects: bool = False,
                  group_search: Optional[str] = None,
@@ -69,6 +70,7 @@ class GitlabTree:
             disable_progress: Whether to disable progress bar (used if config not provided)
             include_shared: Whether to include shared projects (used if config not provided)
             use_fetch: Whether to use git fetch instead of pull (used if config not provided)
+            mirror: Whether to create bare mirror repositories (used if config not provided)
             hide_token: Whether to hide token in URLs (used if config not provided)
             user_projects: Whether to fetch only user projects (used if config not provided)
             group_search: Search term for filtering groups (used if config not provided)
@@ -98,6 +100,7 @@ class GitlabTree:
             disable_progress = config.disable_progress
             include_shared = config.include_shared
             use_fetch = config.use_fetch
+            mirror = config.mirror
             hide_token = config.hide_token
             user_projects = config.user_projects
             group_search = config.group_search
@@ -175,6 +178,7 @@ class GitlabTree:
         self.token = token
         self.include_shared = include_shared
         self.use_fetch = use_fetch
+        self.mirror = mirror
         self.hide_token = hide_token
         self.user_projects = user_projects
         self.group_search = group_search
@@ -308,7 +312,7 @@ class GitlabTree:
                      len(self.root.descendants) - len(self.root.leaves), len(self.root.leaves))
             sync_tree(self.root, dest, concurrency=self.concurrency,
                      disable_progress=self.disable_progress, recursive=self.recursive,
-                     use_fetch=self.use_fetch, hide_token=self.hide_token,
+                     use_fetch=self.use_fetch, mirror=self.mirror, hide_token=self.hide_token,
                      git_options=self.git_options)
         except GitlabberGitError:
             # Re-raise git errors as-is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gitlabber"
-version = "2.1.0"
+version = "2.1.1"
 description = "A Gitlab clone/pull utility for backing up or cloning Gitlab groups"
 readme = "README.rst"
 requires-python = ">=3.11"

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -357,8 +357,8 @@ def test_git_action_collector_mirror_implies_use_fetch():
     
     # Create a simple tree with one project
     root = Node("root", type="root", root_path="")
-    project = Node(type="project", name="test_project", 
-                   root_path="/test_project", url="test_url", parent=root)
+    Node(type="project", name="test_project", 
+         root_path="/test_project", url="test_url", parent=root)
     
     # Test: mirror=True, use_fetch=False - should result in use_fetch=True
     collector = GitActionCollector(

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -217,3 +217,283 @@ def test_clone_repo_options_with_recursive(mock_is_git_repo, mock_git):
     git.clone_or_pull_project(action)
 
     mock_git_repo.Repo.clone_from.assert_called_once_with("dummy_url", "dummy_dir", multi_options=['--recursive','--opt1=1','--opt2=2'])
+
+@mock.patch('gitlabber.git.git')
+@mock.patch('gitlabber.git.is_git_repo')
+def test_clone_repo_mirror(mock_is_git_repo, mock_git):
+    """Test cloning with mirror flag creates bare repository."""
+    mock_git_repo = MockGitRepo.create_mock_repo(is_git_repo=False)
+    mock.patch('gitlabber.git.git', mock_git_repo).start()
+    mock_is_git_repo.return_value = False
+
+    node = Node(type="project", name="dummy_url", url="dummy_url")
+    action = GitAction(node, "dummy_dir", mirror=True)
+    git.clone_or_pull_project(action)
+
+    mock_git_repo.Repo.clone_from.assert_called_once_with("dummy_url", "dummy_dir", multi_options=['--mirror'])
+
+@mock.patch('gitlabber.git.git')
+@mock.patch('gitlabber.git.is_git_repo')
+def test_clone_repo_mirror_with_recursive(mock_is_git_repo, mock_git):
+    """Test cloning with mirror and recursive flags."""
+    mock_git_repo = MockGitRepo.create_mock_repo(is_git_repo=False)
+    mock.patch('gitlabber.git.git', mock_git_repo).start()
+    mock_is_git_repo.return_value = False
+
+    node = Node(type="project", name="dummy_url", url="dummy_url")
+    action = GitAction(node, "dummy_dir", recursive=True, mirror=True)
+    git.clone_or_pull_project(action)
+
+    mock_git_repo.Repo.clone_from.assert_called_once_with("dummy_url", "dummy_dir", multi_options=['--recursive', '--mirror'])
+
+def test_pull_repo_mirror_uses_fetch():
+    """Test that mirror repositories use fetch instead of pull."""
+    mock_git_repo = MockGitRepo.create_mock_repo(is_git_repo=True)
+    with mock.patch('gitlabber.git.git', mock_git_repo):
+        with mock.patch('gitlabber.git.is_git_repo', return_value=True):
+            node = Node(type="project", name="test")
+            action = GitAction(node, "dummy_dir", mirror=True)
+            git.clone_or_pull_project(action)
+            
+            mock_git_repo.Repo.assert_called_once_with("dummy_dir")
+            mock_git_repo.Repo.return_value.remotes.origin.fetch.assert_called_once()
+            mock_git_repo.Repo.return_value.remotes.origin.pull.assert_not_called()
+
+@mock.patch('gitlabber.git.git')
+@mock.patch('gitlabber.git.is_git_repo')
+def test_clone_repo_use_fetch_normal_repo(mock_is_git_repo, mock_git):
+    """Test that use_fetch creates normal repo (not bare) but uses fetch for updates."""
+    mock_git_repo = MockGitRepo.create_mock_repo(is_git_repo=False)
+    mock.patch('gitlabber.git.git', mock_git_repo).start()
+    mock_is_git_repo.return_value = False
+
+    node = Node(type="project", name="dummy_url", url="dummy_url")
+    action = GitAction(node, "dummy_dir", use_fetch=True)
+    git.clone_or_pull_project(action)
+
+    # Should NOT include --mirror, just normal clone
+    mock_git_repo.Repo.clone_from.assert_called_once_with("dummy_url", "dummy_dir", multi_options=[])
+
+@mock.patch('gitlabber.git.git')
+@mock.patch('gitlabber.git.is_git_repo')
+def test_pull_repo_use_fetch(mock_is_git_repo, mock_git):
+    """Test that use_fetch uses fetch instead of pull for updates."""
+    mock_git_repo = MockGitRepo.create_mock_repo(is_git_repo=True)
+    mock.patch('gitlabber.git.git', mock_git_repo).start()
+    mock_is_git_repo.return_value = True
+
+    node = Node(type="project", name="test")
+    action = GitAction(node, "dummy_dir", use_fetch=True)
+    git.clone_or_pull_project(action)
+    
+    mock_git_repo.Repo.assert_called_once_with("dummy_dir")
+    mock_git_repo.Repo.return_value.remotes.origin.fetch.assert_called_once()
+    mock_git_repo.Repo.return_value.remotes.origin.pull.assert_not_called()
+
+def test_use_fetch_and_mirror_interaction():
+    """Test comprehensive interaction between use_fetch and mirror flags.
+    
+    This test ensures:
+    1. use_fetch alone: normal repo, uses fetch for updates
+    2. mirror alone: bare repo, uses fetch for updates (mirror implies use_fetch)
+    3. both flags: bare repo (mirror takes precedence), uses fetch for updates
+    4. mirror=True, use_fetch=False: still uses fetch (mirror implies use_fetch)
+    """
+    # Test 1: use_fetch=True, mirror=False - normal repo, fetch for updates
+    mock_git_repo = MockGitRepo.create_mock_repo(is_git_repo=False)
+    with mock.patch('gitlabber.git.git', mock_git_repo):
+        with mock.patch('gitlabber.git.is_git_repo', return_value=False):
+            node = Node(type="project", name="test1", url="test1_url")
+            action = GitAction(node, "test1_dir", use_fetch=True, mirror=False)
+            git.clone_or_pull_project(action)
+            
+            # Should create normal repo (no --mirror)
+            mock_git_repo.Repo.clone_from.assert_called_once_with("test1_url", "test1_dir", multi_options=[])
+    
+    # Test 2: use_fetch=False, mirror=True - bare repo, fetch for updates (mirror implies use_fetch)
+    mock_git_repo = MockGitRepo.create_mock_repo(is_git_repo=False)
+    with mock.patch('gitlabber.git.git', mock_git_repo):
+        with mock.patch('gitlabber.git.is_git_repo', return_value=False):
+            node2 = Node(type="project", name="test2", url="test2_url")
+            action2 = GitAction(node2, "test2_dir", use_fetch=False, mirror=True)
+            git.clone_or_pull_project(action2)
+            
+            # Should create bare repo (with --mirror)
+            mock_git_repo.Repo.clone_from.assert_called_once_with("test2_url", "test2_dir", multi_options=['--mirror'])
+    
+    # Test 3: use_fetch=True, mirror=True - bare repo (mirror takes precedence), fetch for updates
+    mock_git_repo = MockGitRepo.create_mock_repo(is_git_repo=False)
+    with mock.patch('gitlabber.git.git', mock_git_repo):
+        with mock.patch('gitlabber.git.is_git_repo', return_value=False):
+            node3 = Node(type="project", name="test3", url="test3_url")
+            action3 = GitAction(node3, "test3_dir", use_fetch=True, mirror=True)
+            git.clone_or_pull_project(action3)
+            
+            # Should create bare repo (mirror takes precedence)
+            mock_git_repo.Repo.clone_from.assert_called_once_with("test3_url", "test3_dir", multi_options=['--mirror'])
+    
+    # Test 4: Verify pull behavior - mirror=True should use fetch even if use_fetch=False
+    mock_git_repo = MockGitRepo.create_mock_repo(is_git_repo=True)
+    with mock.patch('gitlabber.git.git', mock_git_repo):
+        with mock.patch('gitlabber.git.is_git_repo', return_value=True):
+            node4 = Node(type="project", name="test4")
+            action4 = GitAction(node4, "test4_dir", use_fetch=False, mirror=True)
+            git.clone_or_pull_project(action4)
+
+            # Mirror should imply use_fetch, so should use fetch, not pull
+            mock_git_repo.Repo.assert_called_once_with("test4_dir")
+            mock_git_repo.Repo.return_value.remotes.origin.fetch.assert_called_once()
+            mock_git_repo.Repo.return_value.remotes.origin.pull.assert_not_called()
+
+
+def test_git_action_collector_mirror_implies_use_fetch():
+    """Test that GitActionCollector correctly implements mirror implies use_fetch logic.
+    
+    This ensures that when mirror=True, the collected GitAction has use_fetch=True
+    even if use_fetch was originally False.
+    """
+    from gitlabber.git import GitActionCollector
+    from anytree import Node
+    
+    # Create a simple tree with one project
+    root = Node("root", type="root", root_path="")
+    project = Node(type="project", name="test_project", 
+                   root_path="/test_project", url="test_url", parent=root)
+    
+    # Test: mirror=True, use_fetch=False - should result in use_fetch=True
+    collector = GitActionCollector(
+        dest="/tmp/test",
+        recursive=False,
+        use_fetch=False,  # Explicitly False
+        mirror=True,      # But mirror is True
+        hide_token=False,
+        git_options=None
+    )
+    
+    actions = collector.collect(root)
+    
+    assert len(actions) == 1
+    action = actions[0]
+    assert action.mirror is True
+    # Mirror should imply use_fetch, so this should be True
+    assert action.use_fetch is True, "mirror=True should imply use_fetch=True"
+    
+    # Test: mirror=True, use_fetch=True - should result in use_fetch=True
+    collector2 = GitActionCollector(
+        dest="/tmp/test",
+        recursive=False,
+        use_fetch=True,
+        mirror=True,
+        hide_token=False,
+        git_options=None
+    )
+    
+    actions2 = collector2.collect(root)
+    assert len(actions2) == 1
+    action2 = actions2[0]
+    assert action2.mirror is True
+    assert action2.use_fetch is True
+    
+    # Test: mirror=False, use_fetch=True - should result in use_fetch=True
+    collector3 = GitActionCollector(
+        dest="/tmp/test",
+        recursive=False,
+        use_fetch=True,
+        mirror=False,
+        hide_token=False,
+        git_options=None
+    )
+    
+    actions3 = collector3.collect(root)
+    assert len(actions3) == 1
+    action3 = actions3[0]
+    assert action3.mirror is False
+    assert action3.use_fetch is True
+    
+    # Test: mirror=False, use_fetch=False - should result in use_fetch=False
+    collector4 = GitActionCollector(
+        dest="/tmp/test",
+        recursive=False,
+        use_fetch=False,
+        mirror=False,
+        hide_token=False,
+        git_options=None
+    )
+    
+    actions4 = collector4.collect(root)
+    assert len(actions4) == 1
+    action4 = actions4[0]
+    assert action4.mirror is False
+    assert action4.use_fetch is False
+
+
+@mock.patch('gitlabber.git.git')
+@mock.patch('gitlabber.git.is_git_repo')
+def test_all_flag_combinations_clone_behavior(mock_is_git_repo, mock_git):
+    """Test all combinations of use_fetch and mirror flags for clone behavior.
+    
+    Verifies that:
+    - Neither flag: normal clone, no special options
+    - use_fetch only: normal clone, no --mirror
+    - mirror only: bare clone with --mirror
+    - both flags: bare clone with --mirror (mirror takes precedence)
+    """
+    test_cases = [
+        # (use_fetch, mirror, expected_multi_options, description)
+        (False, False, [], "Neither flag: normal clone"),
+        (True, False, [], "use_fetch only: normal clone (no --mirror)"),
+        (False, True, ['--mirror'], "mirror only: bare clone"),
+        (True, True, ['--mirror'], "both flags: bare clone (mirror takes precedence)"),
+    ]
+    
+    for use_fetch, mirror, expected_options, description in test_cases:
+        mock_git_repo = MockGitRepo.create_mock_repo(is_git_repo=False)
+        mock.patch('gitlabber.git.git', mock_git_repo).start()
+        mock_is_git_repo.return_value = False
+        
+        node = Node(type="project", name=f"test_{use_fetch}_{mirror}", url="test_url")
+        action = GitAction(node, f"test_dir_{use_fetch}_{mirror}", 
+                         use_fetch=use_fetch, mirror=mirror)
+        git.clone_or_pull_project(action)
+        
+        mock_git_repo.Repo.clone_from.assert_called_once_with(
+            "test_url", 
+            f"test_dir_{use_fetch}_{mirror}", 
+            multi_options=expected_options
+        )
+        assert mock_git_repo.Repo.clone_from.call_args[1]['multi_options'] == expected_options, \
+            f"Failed for {description}: expected {expected_options}, got {mock_git_repo.Repo.clone_from.call_args[1]['multi_options']}"
+
+
+def test_all_flag_combinations_pull_behavior():
+    """Test all combinations of use_fetch and mirror flags for pull/fetch behavior.
+    
+    Verifies that:
+    - Neither flag: uses pull
+    - use_fetch only: uses fetch
+    - mirror only: uses fetch (mirror implies use_fetch)
+    - both flags: uses fetch
+    """
+    test_cases = [
+        # (use_fetch, mirror, should_use_fetch, description)
+        (False, False, False, "Neither flag: should use pull"),
+        (True, False, True, "use_fetch only: should use fetch"),
+        (False, True, True, "mirror only: should use fetch (mirror implies use_fetch)"),
+        (True, True, True, "both flags: should use fetch"),
+    ]
+    
+    for use_fetch, mirror, should_use_fetch, description in test_cases:
+        mock_git_repo = MockGitRepo.create_mock_repo(is_git_repo=True)
+        with mock.patch('gitlabber.git.git', mock_git_repo):
+            with mock.patch('gitlabber.git.is_git_repo', return_value=True):
+                node = Node(type="project", name=f"test_{use_fetch}_{mirror}")
+                action = GitAction(node, f"test_dir_{use_fetch}_{mirror}",
+                                 use_fetch=use_fetch, mirror=mirror)
+                git.clone_or_pull_project(action)
+                
+                if should_use_fetch:
+                    mock_git_repo.Repo.return_value.remotes.origin.fetch.assert_called_once()
+                    mock_git_repo.Repo.return_value.remotes.origin.pull.assert_not_called()
+                else:
+                    mock_git_repo.Repo.return_value.remotes.origin.pull.assert_called_once()
+                    mock_git_repo.Repo.return_value.remotes.origin.fetch.assert_not_called()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -31,6 +31,7 @@ class MockGitRepo:
         mock_git = mock.Mock()
         mock_repo_instance = mock.Mock()
         mock_repo_instance.remotes.origin.pull = mock.Mock()
+        mock_repo_instance.remotes.origin.fetch = mock.Mock()
         if pull_side_effect:
             mock_repo_instance.remotes.origin.pull.side_effect = pull_side_effect
         mock_repo_instance.submodule_update = mock.Mock()
@@ -42,7 +43,8 @@ class MockGitRepo:
         
         # Mock is_git_repo behavior
         if is_git_repo:
-            mock_git.Repo.side_effect = lambda p: mock_repo_instance if p == path else mock.Mock()
+            # Return the same mock_repo_instance for any path when is_git_repo=True
+            mock_git.Repo.side_effect = lambda p: mock_repo_instance
         else:
             mock_git.Repo.side_effect = lambda p: mock.Mock()
             
@@ -286,6 +288,8 @@ class TreeBuilder:
         path: str,
         url: Optional[str] = None,
         recursive: bool = False,
+        use_fetch: bool = False,
+        mirror: bool = False,
         git_options: Optional[str] = None,
     ) -> GitAction:
         """Create a GitAction from a node.
@@ -295,6 +299,8 @@ class TreeBuilder:
             path: Destination path
             url: Repository URL (sets node.url if provided)
             recursive: Whether to clone recursively
+            use_fetch: Whether to use fetch instead of pull
+            mirror: Whether to create bare mirror repository
             git_options: Additional git options
             
         Returns:
@@ -306,6 +312,8 @@ class TreeBuilder:
             node=node,
             path=path,
             recursive=recursive,
+            use_fetch=use_fetch,
+            mirror=mirror,
             git_options=git_options,
         )
 


### PR DESCRIPTION
## Issue Fixed in v2.1.1

This issue has been fixed in version **2.1.1**. Here's what happened and how it was resolved:

### Root Cause

The bug was introduced in [PR #100](https://github.com/ezbz/gitlabber/pull/100) which added support for the `--use-fetch` flag. The original implementation incorrectly added the `--mirror` flag to git clone operations whenever `--use-fetch` was enabled. This caused all repositories cloned with `--use-fetch` to be created as bare repositories (mirrors) instead of normal repositories with a working tree.

### The Fix

The fix separates the concerns of two different use cases:

1. **`--use-fetch` flag**: For users who want normal repositories (with working tree) but prefer using `git fetch` instead of `git pull` for updates. This is useful when you have local branches that no longer exist on the remote.

2. **`--mirror` flag** (new): For users who want bare mirror repositories for backup purposes. This automatically uses `fetch` instead of `pull` for updates, as mirrors should always use fetch.

### Changes Made

- **Removed** the automatic `--mirror` flag from `--use-fetch` clone operations
- **Added** a new `--mirror` flag specifically for creating bare mirror repositories
- **Updated** the `pull` method to check both `use_fetch` and `mirror` flags (mirror implies use_fetch)
- **Added** comprehensive test coverage to ensure both flags work correctly together

### Usage

**For normal repositories with fetch updates:**
```bash
gitlabber --use-fetch -t <token> -u <url> .
```

**For bare mirror repositories (backups):**
```bash
gitlabber --mirror -t <token> -u <url> .
```

### Testing

All flag combinations have been thoroughly tested:
- ✅ `--use-fetch` alone: normal repo, uses fetch
- ✅ `--mirror` alone: bare repo, uses fetch  
- ✅ Both flags: bare repo (mirror takes precedence), uses fetch
- ✅ Neither flag: normal repo, uses pull

The fix is available in **v2.1.1** and has been tested to ensure backward compatibility while fixing the reported issue.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces --mirror for bare backups, decouples it from --use-fetch (which now only switches updates to fetch), propagates config/logic, updates docs, adds comprehensive tests, and bumps to v2.1.1.
> 
> - **CLI/Config/Core**:
>   - Add `--mirror` flag and plumb `mirror` through `gitlabber/cli.py`, `GitlabberConfig`, `GitlabTree`, and git sync APIs (`GitAction`, `GitActionCollector`, `GitSyncManager`, `sync_tree`, `get_git_actions`).
>   - Change clone/update logic: `--use-fetch` no longer adds `--mirror`; `mirror` adds `--mirror` on clone and implies fetch on update.
>   - Update pull path to use fetch when `use_fetch` or `mirror`.
> - **Docs**:
>   - Update option help/descriptions in `README.md`, `README.rst`, `docs/index.rst` for `--use-fetch` and new `--mirror`.
> - **Tests**:
>   - Add extensive tests covering `use_fetch`/`mirror` combinations and interactions; adjust helpers to mock `fetch`.
> - **Version**:
>   - Bump `pyproject.toml` to `2.1.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0319f8b8b054e09f085954e90112846d626cb743. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->